### PR TITLE
LINEBOTPJ-67 重構RichMenuHelper

### DIFF
--- a/api/linebot_helper.py
+++ b/api/linebot_helper.py
@@ -9,9 +9,6 @@ from linebot.v3.messaging import (
     MulticastRequest,
     PushMessageRequest,
     RichMenuRequest,
-    RichMenuArea,
-    RichMenuSize,
-    RichMenuBounds,
     URIAction,
     MessageAction,
     PostbackAction,
@@ -136,100 +133,103 @@ class LineBotHelper:
         else:
             raise ValueError('Invalid action type')
 
+
 class RichMenuHelper:
-    def create_rich_menu_areas(rich_menu):
-        """Returns
-        list: 圖文選單的areas
-        """
-        return [
-            RichMenuArea(
-                bounds=RichMenuBounds(
-                    x=info['bounds']['x'],
-                    y=info['bounds']['y'],
-                    width=info['bounds']['width'],
-                    height=info['bounds']['height']
-                ),
-                action=LineBotHelper.create_action(info['action'])
-            ) for info in rich_menu['areas']
-        ]
-    
-    def create_rich_menu_request(rich_menu, areas):
-        """Returns
-        RichMenuRequest: 圖文選單的request
-        """
-        return RichMenuRequest(
-            size=RichMenuSize(width=rich_menu['size']['width'], height=rich_menu['size']['height']),
-            selected=rich_menu['selected'],
-            name=rich_menu['name'],
-            chat_bar_text=rich_menu['chatBarText'],
-            areas=areas
-        )
-    
-    def set_rich_menu_image(line_bot_blob_api, rich_menu_id, image_url):
+    @staticmethod
+    def set_rich_menu_image_(rich_menu_id, image_url):
         """
         設定圖文選單的圖片
         """
-        response = requests.get(image_url)
-        if response.status_code != 200:
-            raise ValueError('Invalid image url')
-        else:
-            line_bot_blob_api.set_rich_menu_image(
-                rich_menu_id=rich_menu_id,
-                body=response.content,
-                _headers={'Content-Type': 'image/png'}
-            )
-    
-    def create_rich_menu_alias(line_bot_api, alias_id, rich_menu_id):
+        with ApiClient(configuration) as api_client:
+            line_bot_blob_api = MessagingApiBlob(api_client)
+            response = requests.get(image_url)
+            if response.status_code != 200:
+                raise ValueError('Invalid image url')
+            else:
+                line_bot_blob_api.set_rich_menu_image(
+                    rich_menu_id=rich_menu_id,
+                    body=response.content,
+                    _headers={'Content-Type': 'image/png'}
+                )
+
+    @staticmethod
+    def create_rich_menu_alias_(alias_id, rich_menu_id):
         """
         建立圖文選單的alias
         """
-        try:
-            line_bot_api.delete_rich_menu_alias(alias_id)
-        except ApiException as e:
-            if e.status != 404:
-                raise
-        alias = CreateRichMenuAliasRequest(
-            rich_menu_alias_id=alias_id,
-            rich_menu_id=rich_menu_id
-        )
-        line_bot_api.create_rich_menu_alias(alias)
+        with ApiClient(configuration) as api_client:
+            line_bot_api = MessagingApi(api_client)
+            try:
+                line_bot_api.delete_rich_menu_alias(alias_id)
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+            alias = CreateRichMenuAliasRequest(
+                rich_menu_alias_id=alias_id,
+                rich_menu_id=rich_menu_id
+            )
+            line_bot_api.create_rich_menu_alias(alias)
 
     @staticmethod
-    def create_rich_menu():
-        """
-        建立圖文選單
-        """
+    def create_rich_menu_(menu_type, alias_id):
         with ApiClient(configuration) as api_client:
             line_bot_api = MessagingApi(api_client)
             line_bot_blob_api = MessagingApiBlob(api_client)
-
-            # 圖文選單 A
-            rich_menu_a_data = firebaseService.get_data(
+            # 設定 rich menu image
+            rich_menu_str = firebaseService.get_data(
                 DatabaseCollectionMap.RICH_MENU,
-                DatabaseDocumentMap.RICH_MENU.get('a')
-            )
-            rich_menu_a = json.loads(rich_menu_a_data.get('richmenu'))
-            rich_menu_a_to_create = __class__.create_rich_menu_request(rich_menu_a, __class__.create_rich_menu_areas(rich_menu_a))
-
-            rich_menu_a_id = line_bot_api.create_rich_menu(rich_menu_request=rich_menu_a_to_create).rich_menu_id
-            rich_menu_a_url = rich_menu_a_data.get('image_url')
-            __class__.set_rich_menu_image(line_bot_blob_api, rich_menu_a_id, rich_menu_a_url)
-            __class__.create_rich_menu_alias(line_bot_api, 'page1', rich_menu_a_id)
-
-            line_bot_api.set_default_rich_menu(rich_menu_a_id)
-
-            # 圖文選單 B
-            rich_menu_b_data = firebaseService.get_data(
+                DatabaseDocumentMap.RICH_MENU.get(menu_type)
+            ).get('richmenu')
+            rich_menu_id = line_bot_api.create_rich_menu(
+                rich_menu_request=RichMenuRequest.from_json(rich_menu_str)
+            ).rich_menu_id
+            rich_menu_url = firebaseService.get_data(
                 DatabaseCollectionMap.RICH_MENU,
-                DatabaseDocumentMap.RICH_MENU.get("b")
-            )
-            rich_menu_b = json.loads(rich_menu_b_data.get('richmenu'))
-            rich_menu_b_to_create = __class__.create_rich_menu_request(rich_menu_b, __class__.create_rich_menu_areas(rich_menu_b))
-            rich_menu_b_id = line_bot_api.create_rich_menu(rich_menu_request=rich_menu_b_to_create).rich_menu_id
-            rich_menu_b_url = rich_menu_b_data.get('image_url')
-            __class__.set_rich_menu_image(line_bot_blob_api, rich_menu_b_id, rich_menu_b_url)
-            __class__.create_rich_menu_alias(line_bot_api, 'page2', rich_menu_b_id)
+                DatabaseDocumentMap.RICH_MENU.get(menu_type)
+            ).get('image_url')
+            __class__.set_rich_menu_image_(rich_menu_id, rich_menu_url)
+            __class__.create_rich_menu_alias_(alias_id, rich_menu_id)
 
+    #-----------------以下為設定richf menu的程式-----------------
+    # create_rich_menu_('a', 'page1')
+    # create_rich_menu_('b', 'page2')   
+    # with ApiClient(configuration) as api_client:
+    #     line_bot_api = MessagingApi(api_client)
+    #     line_bot_api.set_default_rich_menu(line_bot_api.get_rich_menu_alias('page1').rich_menu_id)
+
+    #-----------------以下為sdk提供的方法-----------------
+    # with ApiClient(configuration) as api_client:
+    #     line_bot_api = MessagingApi(api_client)
+    #     line_bot_api_blob = MessagingApiBlob(api_client)
+    #     # CRUD of rich menu
+    #     line_bot_api.create_rich_menu(RichMenuRequest.from_json(
+    #         firebaseService.get_data(
+    #             DatabaseCollectionMap.RICH_MENU,
+    #             DatabaseDocumentMap.RICH_MENU
+    #         )
+    #     ))
+    #     line_bot_api.get_rich_menu('a')
+    #     line_bot_api.get_rich_menu_list()
+    #     line_bot_api.set_default_rich_menu('a')
+    #     line_bot_api.delete_rich_menu('a')
+    #     # CRUD of rich menu alias
+    #     line_bot_api.create_rich_menu_alias(
+    #         CreateRichMenuAliasRequest(
+    #             richMenuAliasId='page1',
+    #             richMenuId='a'
+    #         )
+    #     )
+    #     line_bot_api.get_rich_menu_alias('page1')
+    #     line_bot_api.get_rich_menu_alias_list()
+    #     line_bot_api.update_rich_menu_alias(
+    #         'page1',
+    #         CreateRichMenuAliasRequest(richMenuAliasId='page1', richMenuId='a')
+    #     )
+    #     line_bot_api.delete_rich_menu_alias('page1')
+    #     # CRUD of rich menu image
+    #     line_bot_api_blob.get_rich_menu_image('a')
+    #     line_bot_api_blob.set_rich_menu_image('a', 'image_path')
+    
 class QuickReplyHelper:
     @staticmethod
     def create_quick_reply(quick_reply_data: list[dict]):

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from config import Config
 from strategy import TaskStrategy, TemplateStrategy
 from map import Map, FeatureStatus, Permission
-from api.linebot_helper import LineBotHelper, RichMenuHelper
+from api.linebot_helper import LineBotHelper
 from flask import Flask, request, abort
 from line_notify_app import line_notify_app
 from linebot.v3.exceptions import (
@@ -147,10 +147,7 @@ def handle_postback(event):
         task = strategy_class()
         task.execute(event, params)
         return
-      
 
-# 初始化 Rich Menu
-RichMenuHelper.create_rich_menu()
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
1.將app.py中的create_rich_menu移除，這樣每次啟動bot不會再建立richmenu
2.將RichMenuHelper中所有不需要方法移除
3.改寫RichMenuHelper的create_rich_menu_()，並把呼叫的地方註解掉
4.把set_default_rich_menu_移到funtion外並用sdk提供的方法處理
5.在RichMenuHelper中留下所有messaging API提供的方法，將其寫入並註解，以供日後參考使用