### PR TITLE
LINEBOTPJ-76 Richmenu生成錯誤

### DIFF
--- a/api/linebot_helper.py
+++ b/api/linebot_helper.py
@@ -190,45 +190,55 @@ class RichMenuHelper:
             __class__.set_rich_menu_image_(rich_menu_id, rich_menu_url)
             __class__.create_rich_menu_alias_(alias_id, rich_menu_id)
 
-    #-----------------以下為設定richf menu的程式-----------------
-    # create_rich_menu_('a', 'page1')
-    # create_rich_menu_('b', 'page2')   
-    # with ApiClient(configuration) as api_client:
-    #     line_bot_api = MessagingApi(api_client)
-    #     line_bot_api.set_default_rich_menu(line_bot_api.get_rich_menu_alias('page1').rich_menu_id)
+#-----------------以下為設定rich menu的程式-----------------
+RichMenuHelper.create_rich_menu_('a', 'page1')
+RichMenuHelper.create_rich_menu_('b', 'page2')
+with ApiClient(configuration) as api_client:
+    line_bot_api = MessagingApi(api_client)
+    line_bot_api.set_default_rich_menu(line_bot_api.get_rich_menu_alias('page1').rich_menu_id)
 
-    #-----------------以下為sdk提供的方法-----------------
-    # with ApiClient(configuration) as api_client:
-    #     line_bot_api = MessagingApi(api_client)
-    #     line_bot_api_blob = MessagingApiBlob(api_client)
-    #     # CRUD of rich menu
-    #     line_bot_api.create_rich_menu(RichMenuRequest.from_json(
-    #         firebaseService.get_data(
-    #             DatabaseCollectionMap.RICH_MENU,
-    #             DatabaseDocumentMap.RICH_MENU
-    #         )
-    #     ))
-    #     line_bot_api.get_rich_menu('a')
-    #     line_bot_api.get_rich_menu_list()
-    #     line_bot_api.set_default_rich_menu('a')
-    #     line_bot_api.delete_rich_menu('a')
-    #     # CRUD of rich menu alias
-    #     line_bot_api.create_rich_menu_alias(
-    #         CreateRichMenuAliasRequest(
-    #             richMenuAliasId='page1',
-    #             richMenuId='a'
-    #         )
-    #     )
-    #     line_bot_api.get_rich_menu_alias('page1')
-    #     line_bot_api.get_rich_menu_alias_list()
-    #     line_bot_api.update_rich_menu_alias(
-    #         'page1',
-    #         CreateRichMenuAliasRequest(richMenuAliasId='page1', richMenuId='a')
-    #     )
-    #     line_bot_api.delete_rich_menu_alias('page1')
-    #     # CRUD of rich menu image
-    #     line_bot_api_blob.get_rich_menu_image('a')
-    #     line_bot_api_blob.set_rich_menu_image('a', 'image_path')
+#-----------------以下為sdk提供的方法-----------------
+# with ApiClient(configuration) as api_client:
+#     line_bot_api = MessagingApi(api_client)
+#     line_bot_api_blob = MessagingApiBlob(api_client)
+#     # CRUD of rich menu
+#     line_bot_api.create_rich_menu(
+#         rich_menu_request=RichMenuRequest.from_json(firebaseService.get_data(
+#                 DatabaseCollectionMap.RICH_MENU,
+#                 DatabaseDocumentMap.RICH_MENU.get('a')
+#         ).get('richmenu'))
+#     ).rich_menu_id
+#     line_bot_api.get_rich_menu('a')
+#     line_bot_api.get_rich_menu_list()
+#     line_bot_api.set_default_rich_menu('a')
+#     line_bot_api.delete_rich_menu('a')
+#     # CRUD of rich menu alias
+#     line_bot_api.create_rich_menu_alias(
+#         CreateRichMenuAliasRequest(
+#             richMenuAliasId='page1',
+#             richMenuId='a'
+#         )
+#     )
+#     line_bot_api.get_rich_menu_alias('page1')
+#     line_bot_api.get_rich_menu_alias_list()
+#     line_bot_api.update_rich_menu_alias(
+#         'page1',
+#         CreateRichMenuAliasRequest(richMenuAliasId='page1', richMenuId='a')
+#     )
+#     line_bot_api.delete_rich_menu_alias('page1')
+#     # CRUD of rich menu image
+#     line_bot_api_blob.get_rich_menu_image('a')
+#     response = requests.get(firebaseService.get_data(
+#         DatabaseCollectionMap.RICH_MENU,
+#         DatabaseDocumentMap.RICH_MENU.get('a')
+#     ).get('image_url'))
+#     image_content = response.content
+#     headers = {'Content-Type': 'image/png'}
+#     line_bot_api_blob.set_rich_menu_image(
+#         rich_menu_id='richmenu-c88b6b533abd76ac9068cf5296720e60',
+#         body=image_content,
+#         _headers=headers
+#     )
     
 class QuickReplyHelper:
     @staticmethod


### PR DESCRIPTION
1.將設定richmenu的程式改為正確的縮排位置
2.將sdk提供的方法修正，把MAP的資料位置改為正確的
3.修正sdk提供的方法中的set_rich_menu_image的參數，將參數一起寫在程式中，執行時才不會有錯誤