### PR TITLE
LINEBOTPJ-89 限時測驗

### DIFF
--- a/api/linebot_helper.py
+++ b/api/linebot_helper.py
@@ -22,6 +22,8 @@ import requests
 import random
 import json
 import re
+import pytz
+from datetime import datetime
 
 config = Config()
 configuration = config.configuration
@@ -31,7 +33,7 @@ class LineBotHelper:
     @staticmethod
     def get_user_info(user_id: str):
         """Returns 使用者資訊
-        list: [使用者名稱, 使用者大頭貼]
+        list: [使用者名稱, 使用者大頭貼, 使用者語系, 使用者狀態訊息]
         """
         with ApiClient(configuration) as api_client:
             line_bot_api = MessagingApi(api_client)
@@ -90,6 +92,26 @@ class LineBotHelper:
                     messages=messages
                 )
             )
+            
+    @staticmethod
+    def get_current_time():
+        """Returns
+        datetime: 現在時間
+        """
+        return datetime.now(pytz.timezone('Asia/Taipei'))
+    
+    @staticmethod
+    def convert_timedelta_to_string(timedelta):
+        """Returns
+        str: 時間字串 (小時:分鐘:秒 e.g. 01:20:43)
+        """
+        hours = timedelta.days * 24 + timedelta.seconds // 3600
+        minutes = (timedelta.seconds % 3600) // 60
+        seconds = timedelta.seconds % 60
+        hours = hours if len(str(hours)) >= 2 else f'0{hours}'
+        minutes = minutes if len(str(minutes)) == 2 else f'0{minutes}'
+        seconds = seconds if len(str(seconds)) == 2 else f'0{seconds}'
+        return f'{hours}:{minutes}:{seconds}'
     
     @staticmethod
     def generate_id(k: int=20):

--- a/api/spreadsheet.py
+++ b/api/spreadsheet.py
@@ -28,20 +28,20 @@ class SpreadsheetService:
         """
         return wks.get_row(1).index(column_name) + 1
     
-    def get_user_row_index(self, wks, user_id):
+    def get_row_index(self, wks, column_name, value):
         """Returns
-        int: user_id 所在的 row index
+        int: value 所在的 row index
         """
-        column_index = self.get_column_index(wks, 'user_id')
-        user_ids = wks.get_col(column_index)
-        return user_ids.index(user_id) + 1
+        column_index = self.get_column_index(wks, column_name)
+        column_values = wks.get_col(column_index)
+        return column_values.index(value) + 1
         
     def set_user_status(self, user_id, is_active):
         """
         設定使用者的is_active及更新時間
         """
         wks = self.sh.worksheet_by_title('user_info')
-        user_row_index = self.get_user_row_index(wks, user_id)
+        user_row_index = self.get_row_index(wks, 'user_id', user_id)
         column_index = self.get_column_index(wks, 'is_active')
         wks.update_value((user_row_index, column_index), is_active)
         #紀錄時間
@@ -68,11 +68,23 @@ class SpreadsheetService:
             更新工作表資料
         Args:
             title: 工作表名稱
-            index: 要更新的列索引
-            data: 要更新的資料
+            range: 要更新的列索引(E.g. (row, col))
+            value: 要更新的資料
         """
         wks = self.sh.worksheet_by_title(title)
         wks.update_value(range, value)
+        
+    def update_cells_values(self, title: str, range: str, values: list):
+        """
+        Summary:
+            更新工作表資料
+        Args:
+            title: 工作表名稱
+            range: 要更新的列索範圍(E.g. 'A1:B1')
+            values: 要更新的資料(E.g. [['row1-1', 'row1-2']] 或 [['row1'], ['row2']])
+        """
+        wks = self.sh.worksheet_by_title(title)
+        wks.update_values(range, values)
     
     def delete_row_data(self, title, index):
         """

--- a/line_notify_app.py
+++ b/line_notify_app.py
@@ -37,7 +37,7 @@ def line_notify():
     # 若使用者已存在，代表先前已經連動過，需先刪除再新增
     if spreadsheetService.check_user_exists('notify_info', user_id):
         wks = spreadsheetService.sh.worksheet_by_title('notify_info')
-        user_row_index = spreadsheetService.get_user_row_index(wks, user_id)
+        user_row_index = spreadsheetService.get_row_index(wks, 'user_id', user_id)
         spreadsheetService.delete_row_data('notify_info', user_row_index)
     spreadsheetService.add_user('notify_info', user_info)
     msg = "感謝您連動「國北教大教育大數據微學程」Line Notify 推播服務，若未來您想解除連動，請點選 https://notify-bot.line.me/my/ 後將連動解除即可。"


### PR DESCRIPTION
1. 拿掉mode的判別，改以spreadsheet後台設定測驗的開啟以及測驗限時的設定(若時間為空則不判別，新增enable及start_time、end_time欄位)
2. 將quiz改成放置quiz的flex的資料表，新增quiz_questions去放題目
3. 將紀錄timestamp的欄位改成字串的日期時間格式
4. 新增competition用來區分一般測驗和競賽測驗的個人紀錄
5. 設定防止限時測驗時間已結束後使用者可以繼續作答
6. 將生成測驗結果區分為一般測驗的結果和限時測驗的結果
7. 新增一個確認是否在限時測驗時間範圍內的方法
8. 新增question_amount和database_amount來設計限時測驗抽題規則
