### PR TITLE
LINEBOTPJ-126 解決Firestore讀取次數問題

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ def handle_unfollow(event):
     try:
         user_id = event.source.user_id
         # 使用者在資料庫中的isActive設定為False
-        firebaseService.update_data('users', user_id, {'isActive': False})
+        firebaseService.update_data(DatabaseCollectionMap.USER, user_id, {'isActive': False})
     except Exception as e:
         app.logger.error(e)
         error_message = ''.join(traceback.format_exception(None, e, e.__traceback__))

--- a/features/course.py
+++ b/features/course.py
@@ -36,13 +36,13 @@ class Course(Feature):
             # 查詢修課進度
             user_id = event.source.user_id
 
-            user_detail = self.firebaseService.filter_data('users', [('userId', '==', user_id)])[0].get('details')
+            user_detail = self.firebaseService.get_data(DatabaseCollectionMap.USER, user_id).get('details')
             # 確認使用者填完的資料是否已經認證
             if not user_detail or not user_detail['verification']:
                 return LineBotHelper.reply_message(event, [TextMessage(text='請先在圖文選單點擊【設定】中的【設定個人資料】填寫表單，並傳送學生證正面照片完成認證')])
 
             student_id = user_detail['studentId']
-            user_courses = self.firebaseService.filter_data('course_study_records', [('student_id', '==', student_id)])
+            user_courses = self.firebaseService.filter_data(DatabaseCollectionMap.COURSE_STUDY, [('student_id', '==', student_id)])
             # 取得課程資料
             courses_df = pd.DataFrame(self.firebaseService.get_collection_data(DatabaseCollectionMap.COURSE))
             courses_records_df = pd.DataFrame(self.firebaseService.get_collection_data(DatabaseCollectionMap.COURSE_OPEN))

--- a/features/equipment.py
+++ b/features/equipment.py
@@ -76,7 +76,7 @@ class Equipment(Feature):
             ('type', '==', int(params.pop('equipmentId'))),
             ('status', '==', EquipmentStatus.AVAILABLE)
         ]
-        equipment_status_data = self.firebaseService.filter_data('equipments', conditions)
+        equipment_status_data = self.firebaseService.filter_data(DatabaseCollectionMap.EQUIPMENT, conditions)
         # 隨機產生id
         borrower_id = LineBotHelper.generate_id()
         params.update({
@@ -94,7 +94,7 @@ class Equipment(Feature):
         rent_amount = int(params.pop('equipmentAmount'))
         # 更新設備狀態
         for equipment in equipment_status_data[:rent_amount]:
-            self.firebaseService.update_data('equipments', equipment.get('_id'), params)
+            self.firebaseService.update_data(DatabaseCollectionMap.EQUIPMENT, equipment.get('_id'), params)
         return borrower_id
     
     def __get_borrow_records(self, user_id: str, borrower_id: str=None):
@@ -102,12 +102,12 @@ class Equipment(Feature):
         list: 借用紀錄
         """
         conditions = [('borrower', '==', user_id)]
-        equipments = self.firebaseService.filter_data('equipments', conditions)
+        equipments = self.firebaseService.filter_data(DatabaseCollectionMap.EQUIPMENT, conditions)
 
         if borrower_id:
             conditions.append(('borrowerId', '==', borrower_id))
 
-        equipments = self.firebaseService.filter_data('equipments', conditions)
+        equipments = self.firebaseService.filter_data(DatabaseCollectionMap.EQUIPMENT, conditions)
         borrow_records_dict = {}
         for equipment in equipments:
             # borrower_id_ 多一個底線是為了避免與參數名稱衝突


### PR DESCRIPTION
1. 新增get_aggregate_count()用來取得查詢資料的筆數
2. 在filter_data()新增limit參數，可以限制筆數，並將order_by參數改為tuple，(欄位名稱, asc或desc)
3. 減少使用get_collection_data() 一次取得所有document，改使用filter_data()減少讀取次數